### PR TITLE
hostports: Add support for host ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,14 @@ $ sudo cp ipdk.json /etc/docker/plugins/
 Start the plugin
 
 ```
-$ sudo ./ipdk-plugin&
+$ sudo ./ipdk-plugin &
+```
+
+To run the plugin such that it exposes a GW port into the host where docker is
+running, add `-hostports` to the command line:
+
+```
+$ sudo ./ipdk-plugin -hostports &
 ```
         
 Note: Enable password less sudo to ensure the plugin will run in the background without prompting.


### PR DESCRIPTION
This adds support to expose the GW port on each IPDK p4-ebpf network
into the host itself. This allows for the host to communicate to
containers on the IPDK p4-ebpf network. Since we don't support exposing
ports, this allows for similar functionality.

Signed-off-by: Kyle Mestery <mestery@mestery.com>